### PR TITLE
Added response code handling for individual agents

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ function getAgentDetails(href, callback) {
           body += d;
       });
       response.on('end', function() {
+          if (response.statusCode !== 200) {
+            body = `{}`;
+            console.log(colors.yellow("WARN: Server returned status code " + response.statusCode + " when trying to get agent details from '" + href + "'. Ignoring this agent and moving on."));
+          }
           var parsed = JSON.parse(body);
           callback(parsed);
       });
@@ -283,7 +287,7 @@ function updateCloudImage(cloudProfile, cloudImage, newImage, callback) {
           body += d;
       });
       response.on('end', function() {
-        console.log(colors.gray("VERBOSE" + body));
+        console.log(colors.gray("VERBOSE: " + body));
         callback();
       });
   });


### PR DESCRIPTION
We found that in some cases, agents would be cleaned and removed prior to the tool being able to get through to updating them. This would return a 404 for the cleaned resource and fail due to JSON parse errors. This PR introduces a check for the response code. If it's not 200, it will print the problem resource and continue with the rest of the agents.