### PR TITLE
Add functionality to clean up superseded agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,28 @@
 # TeamCityCloudAgentUpdater
 
-Simple NodeJS app to update images for TeamCity Cloud Agents, via the 2017.1 API. Also disables any agents that are running that are based on the old image.
+When building a new teamcity agent image (e.g., via [packer](packer.io)), once it's built, you need to tell TeamCity to start using it.
+
+This is a simple NodeJS app that can:
+1. updates TeamCity Cloud Agents images and disable any agents that are running that are based on the old image
+2. remove any agents that were disabled during update that are no longer running a build
 
 ## Usage
 
+To update a cloud profile (whenever you have a new agent):
 ```
-node index.js --username myusername --password MyPassword --server https://teamcity.example.com --image ami-XXXXXXX --cloudprofile "AWS Agents" --agentprefix "Ubuntu"
+node index.js [update-cloud-image] --token XXXXX --server https://teamcity.example.com --image ami-XXXXXXX --cloudprofile "AWS Agents" --agentprefix "Ubuntu" [--dryrun]
+```
 
+To remove any agents that were disabled as part of the update, and are no longer running a build (run on a schedule):
 ```
+node index.js remove-disabled-agents --token XXXXX --server https://teamcity.example.com [--dryrun]
+```
+
+The `--dryrun` flag allows you to check what actions the script would have taken with out any real modifications.
+
+## Requiremens
+
+This app uses features (user access tokens) that require TeamCity `2019.1` or newer.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # TeamCityCloudAgentUpdater
 
-When building a new teamcity agent image (e.g., via [packer](packer.io)), once it's built, you need to tell TeamCity to start using it.
+When a new TeamCity agent image is built (e.g., via [packer](packer.io)), you need to tell TeamCity to start using it. 
 
 This is a simple NodeJS app that can:
-1. updates TeamCity Cloud Agents images and disable any agents that are running that are based on the old image
+1. update TeamCity Cloud Agents images and disable any agents that are running that are based on the old image
 2. remove any agents that were disabled during update that are no longer running a build
 
 ## Usage
 
-To update a cloud profile (whenever you have a new agent):
+When you have a new agent, update the cloud profile:
 ```
 node index.js [update-cloud-image] --token XXXXX --server https://teamcity.example.com --image ami-XXXXXXX --cloudprofile "AWS Agents" --agentprefix "Ubuntu" [--dryrun]
 ```

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function shortenImage(image) {
   return splitImage[splitImage.length - 1]
 }
 
-function disableAgent(server, agent, oldImage, newImage, dryrun) {
+function disableAgent(server, auth, agent, oldImage, newImage, dryrun) {
 
   if (dryrun) {
     console.log(colors.cyan("INFO: Would have disabled agent " + agent.id + " from teamcity."));
@@ -139,7 +139,7 @@ function disableAgentWith(server, auth, agents, oldImage, newImage, dryrun) {
   agents.forEach(function(agent) {
       getAgentDetails(server, auth, agent.href, function(agentDetails) {
         var success = function(agent) {
-            disableAgent(agent, oldImage, newImage, dryrun);
+            disableAgent(server, auth, agent, oldImage, newImage, dryrun);
         };
         var failure = function () {
           failureCount++;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "teamcity-cloud-agent-updater",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "teamcity-cloud-agent-updater",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "colors": "1.4.0",
+        "commander": "9.3.0"
+      }
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://packages.test.octopushq.com/artifactory/api/npm/npm/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.3.0",
+      "resolved": "https://packages.test.octopushq.com/artifactory/api/npm/npm/commander/-/commander-9.3.0.tgz",
+      "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    }
+  },
+  "dependencies": {
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://packages.test.octopushq.com/artifactory/api/npm/npm/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "commander": {
+      "version": "9.3.0",
+      "resolved": "https://packages.test.octopushq.com/artifactory/api/npm/npm/commander/-/commander-9.3.0.tgz",
+      "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw=="
+    }
+  }
+}


### PR DESCRIPTION
When we publish a new agent, we disable the old agent, and rely on teamcity to clean it up.

In a recent-ish update (2022.10?) teamcity agent behaviour changed, so that cloud agents weren't terminated if they were disabled - it assumes they should be kept around for maintenance/investigation.

This PR adds a new command to the app, to cleanup old agents. We'll run this on a schedule to terminate old agents.

```
node index.js remove-disabled-agents --token XXXXX --server https://teamcity.example.com [--dryrun]
```

[sc-34780]