### PR TITLE
Fix issue showing build id when build is still running

### DIFF
--- a/index.js
+++ b/index.js
@@ -398,7 +398,7 @@ function removeAgentIfSuperseded(server, auth, agents, dryrun) {
           /Disabling agent as it uses base image .*, which has been superseded by base image .*\./.test(agentDetails.enabledInfo.comment.text)) {
           console.log(colors.cyan("INFO: Agent " + agentDetails.name + " uses old image and should be cleaned up (it had comment '" + agentDetails.enabledInfo.comment.text + "')"));
           if (agentDetails.hasOwnProperty("build")) {
-            console.log(colors.cyan("INFO: Agent " + agentDetails.name + " is still running a build (" + agent.build.id + "), skipping cleanup this time round."));
+            console.log(colors.cyan("INFO: Agent " + agentDetails.name + " is still running a build (" + agentDetails.build.id + "), skipping cleanup this time round."));
             failure(agentDetails);
           } else {
             success(agentDetails);

--- a/index.js
+++ b/index.js
@@ -412,9 +412,7 @@ function removeAgentIfSuperseded(server, auth, agents, dryrun) {
 }
 
 var removeDisabledAgents = function(server, auth, dryrun) {
-  console.log("removing disabled agents")
-
-  console.log(colors.cyan("INFO: Attempting to remove old disabled teamcity agents that have been replaced by newwer images"));
+  console.log(colors.cyan("INFO: Attempting to remove old disabled teamcity agents that have been replaced by newer images"));
   getAuthorisedAgents(server, auth, function(response) {
     var agents = response.agent;
     removeAgentIfSuperseded(server, auth, agents, dryrun);


### PR DESCRIPTION
Got a [failure](https://build.octopushq.com/buildConfiguration/TeamEngineeringProductivity_Janitors_CleanupSupersededAgents/8935746?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&showLog=8935746_478_468&logView=flowAware) trying to show the build id 

```
10:39:31   INFO: Attempting to remove old disabled teamcity agents that have been replaced by newwer images
10:39:32   INFO: Agent amazonlinux2-i-045094be91bc1a29b uses old image and should be cleaned up (it had comment 'Disabling agent as it uses base image ami-0b14330a95325e15f, which has been superseded by base image ami-0d76391f328f5ed93.')
10:39:32   /opt/buildagent/work/9822c37f8fd5edf/index.js:401
10:39:32               console.log(colors.cyan("INFO: Agent " + agentDetails.name + " is still running a build (" + agent.build.id + "), skipping cleanup this time round."));
10:39:32                                                                                                                        ^
10:39:32   
10:39:32   TypeError: Cannot read property 'id' of undefined
10:39:32       at /opt/buildagent/work/9822c37f8fd5edf/index.js:401:118
10:39:32       at IncomingMessage.<anonymous> (/opt/buildagent/work/9822c37f8fd5edf/index.js:49:11)
10:39:32       at IncomingMessage.emit (events.js:326:22)
10:39:32       at endReadableNT (_stream_readable.js:1241:12)
10:39:32       at processTicksAndRejections (internal/process/task_queues.js:84:21)
10:39:32   Process exited with code 1
```

Turns out I was looking at `agent`, not `agentDetails`