### PR TITLE
Support disabling superseded azure agents

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ function checkAgentMatches(agent, image, cloudProfileId, success, failure) {
       console.log(colors.cyan("INFO: Disabling agent " + agent.id + " as it uses old image " + reportedImageId));
       success(agent);
     } else if (cloudProfileId == agentCloudProfileId) {
-      console.log(colors.cyan("INFO: Disabling agent " + agent.id + " as it uses old image " + cloudProfileId));
+      console.log(colors.cyan("INFO: Disabling agent " + agent.id + " as it uses cloud profile " + cloudProfileId));
       success(agent);
     } else {
       failure(agent);

--- a/index.js
+++ b/index.js
@@ -320,7 +320,7 @@ var updateCloudImage = function(server, auth, cloudProfileName, agentPrefix, ima
 
     var currentImage = getFeatureProperty(cloudImage, imageProperty);
     var newImage = tweakImageName(cloudProfile, cloudImage, image);
-    if (false) { //currentImage == newImage) { //nocommit
+    if (currentImage == newImage) {
       console.log(colors.cyan("INFO: TeamCity cloud profile '" + cloudProfileName + "', image '" + agentPrefix + "' is already set to use '" + newImage + "'"));
     } else {
         setFeatureProperty(cloudImage, imageProperty, newImage);


### PR DESCRIPTION
I was trying to figure out why [agent](https://build.octopushq.com/agent/1448768?tab=parameters&iframeSrc=https%3A%2F%2Fbuild.octopushq.com%2FagentDetails.html%3Fid%3D1448768%26tab%3DagentParameters%26kind%3Dconf%26embedded%3Dtrue)

![image](https://github.com/OctopusDeploy/TeamCityCloudAgentUpdater/assets/373389/ab8a3953-a3ce-40a3-8b63-4cb35bc346bb)

was still hanging around.

Turned out it was from [this build](https://build.octopushq.com/buildConfiguration/Infrastructure_TeamCityBuildAgents_WindowsServer2022Docker/9487773?buildTab=log&focusLine=4808&logView=flowAware&linesState=591.4819), which had the logs:

```
12:03:38   INFO: TeamCity cloud profile 'Azure Docker Cloud Agents', image 'win2022-dckr' is currently set to use '/subscriptions/79ad7466-af4b-476e-bf72-2b235ef82801/resourceGroups/TEAMCITY-BUILD-AGENTS/providers/Microsoft.Compute/images/teamcity-agent-windows-2022-with-docker-v0.0.13'. Updating to use '/subscriptions/79ad7466-af4b-476e-bf72-2b235ef82801/resourceGroups/TEAMCITY-BUILD-AGENTS/providers/Microsoft.Compute/images/teamcity-agent-windows-2022-with-docker-v0.0.14'.
12:03:39   VERBOSE: Server returned status code 200
12:03:39   INFO: Successfully updated cloudImage PROJECT_EXT_786 in teamcity.
12:03:39   VERBOSE: /subscriptions/79ad7466-af4b-476e-bf72-2b235ef82801/resourceGroups/TEAMCITY-BUILD-AGENTS/providers/Microsoft.Compute/images/teamcity-agent-windows-2022-with-docker-v0.0.14
12:03:39   INFO: Attempting to disable teamcity agents that use image /subscriptions/79ad7466-af4b-476e-bf72-2b235ef82801/resourceGroups/TEAMCITY-BUILD-AGENTS/providers/Microsoft.Compute/images/teamcity-agent-windows-2022-with-docker-v0.0.13
12:03:40   INFO: No agents with image = '/subscriptions/79ad7466-af4b-476e-bf72-2b235ef82801/resourceGroups/TEAMCITY-BUILD-AGENTS/providers/Microsoft.Compute/images/teamcity-agent-windows-2022-with-docker-v0.0.13' found. Nothing to disable.
```

It wasn't able to find the right agent to disable.

Looking at the code, it had a comment:

```
//todo: needs fixing to work for azure as well
```

🤦 

## Results

This PR adds support for the azure agents, so they get cleaned up properly.