### PR TITLE
Update after commander update

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var program = require('commander');
+const { Command } = require('commander');
+const program = new Command();
+
 var colors = require('colors/safe');
 var http = require('https');
 const { fail } = require('assert');
@@ -249,7 +251,7 @@ var getCloudImage = function(cloudProfile, agentPrefix, response) {
 function updateCloudImageOnTeamCity(server, auth, cloudProfile, cloudImage, currentImage, newImage, cloudProfileName, agentPrefix, dryrun, callback) {
   if (dryrun) {
     console.log(colors.cyan("INFO: TeamCity cloud profile '" + cloudProfileName + "', image '" + agentPrefix + "' is currently set to use '" + currentImage + "'. Would update to use '" + newImage + "'."));
-    callback();
+    callback(cloudProfile.id);
     return;
   } else {
     console.log(colors.cyan("INFO: TeamCity cloud profile '" + cloudProfileName + "', image '" + agentPrefix + "' is currently set to use '" + currentImage + "'. Updating to use '" + newImage + "'."));


### PR DESCRIPTION
The upgrade in https://github.com/OctopusDeploy/TeamCityCloudAgentUpdater/pull/27 fell over.

~It is confusing how it managed to get a green build though.~

Looks like our build only publishes, doesn't run any tests.
The run happens over [here](https://build.octopushq.com/buildConfiguration/TeamEngineeringProductivity_Janitors_CleanupSupersededAgents/11071880?buildTab=log&focusLine=491&logView=flowAware&linesState=461.464)