### PR TITLE
Update CODEOWNERS: team-rock-solid-builds → team-build-foundations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @OctopusDeploy/team-rock-solid-builds
+* @OctopusDeploy/team-build-foundations


### PR DESCRIPTION
## Update CODEOWNERS

This PR updates the CODEOWNERS file to reflect the team rename from `@OctopusDeploy/team-rock-solid-builds` to `@OctopusDeploy/team-build-foundations`.

No functional change — this is a team ownership rename only.